### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+    - uses: actions/checkout@v2
+    - name: Check formatting
+      run: cargo fmt -- --check
+    - name: Clippy
+      run: cargo clippy -- -D warnings -W clippy::pedantic
+    - name: markdownlint
+      uses: articulate/actions-markdownlint@v1
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        targets: wasm32-unknown-unknown
+    - name: Install Trunk
+      uses: jetli/trunk-action@v0.1.0
+    - uses: actions/checkout@v2
+    - name: Build
+      run: trunk build
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# github-dashboard-client
-AICE GitHub Dashboard Client
+# AICE GitHub Dashboard Client
 
-# Usage
-Build and serve with Trunk. Should be running on http://127.0.0.1:8080
+## Usage
 
-```
+Build and serve with Trunk. Should be running on <http://127.0.0.1:8080>.
+
+```sh
 trunk build
 trunk serve
 ```


### PR DESCRIPTION
CI succeeds only if all the followings pass:

* cargo fmt
* cargo clippy
* cargo test
* trunk build
* markdownlint

This also fixes markdownlint errors in README.md.