### PR TITLE
Derive `Eq` when it is free

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_partial_eq_without_eq)] // GraphQLQuery implements PartialEq but not Eq
+
 use crate::CommonError;
 use anyhow::{anyhow, Result};
 use gloo_net::http::Request;

--- a/src/home.rs
+++ b/src/home.rs
@@ -23,7 +23,7 @@ pub struct Model {
     id_token: String,
 }
 
-#[derive(Properties, Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Properties)]
 pub struct Props {}
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This also silences [clippy warnings](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) with Rust 1.63.
