### PR TITLE
Enforce import grouping in formatting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,30 +9,30 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy, rustfmt
-    - name: Check formatting
-      run: cargo fmt -- --check
-    - name: Clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic
-    - name: markdownlint
-      uses: articulate/actions-markdownlint@v1
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt -- --check --config group_imports=StdExternalCrate
+      - name: Clippy
+        run: cargo clippy -- -D warnings -W clippy::pedantic
+      - name: markdownlint
+        uses: articulate/actions-markdownlint@v1
 
   wasm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: wasm32-unknown-unknown
-    - name: Install Trunk
-      uses: jetli/trunk-action@v0.2.0
-    - name: Build
-      run: trunk build
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install Trunk
+        uses: jetli/trunk-action@v0.2.0
+      - name: Build
+        run: trunk build
 
   test:
     runs-on: ${{ matrix.os }}
@@ -40,10 +40,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::derive_partial_eq_without_eq)] // GraphQLQuery implements PartialEq but not Eq
 
-use crate::CommonError;
 use anyhow::{anyhow, Result};
 use gloo_net::http::Request;
 use graphql_client::QueryBody;
@@ -8,6 +7,7 @@ use graphql_client::{GraphQLQuery, Response as GraphQlResponse};
 use serde::Serialize;
 use yew::{Component, Context};
 
+use crate::CommonError;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/schema.graphql",

--- a/src/home.rs
+++ b/src/home.rs
@@ -1,6 +1,3 @@
-use crate::fetch::{Common, Issues, Pulls, QueryIssue, QueryPull};
-use crate::top_pane::TopModel;
-use crate::CommonError;
 use gloo_console::log;
 use gloo_events::EventListener;
 use gloo_utils::format::JsValueSerdeExt;
@@ -11,6 +8,10 @@ use yew::{
     prelude::*,
     {html, Component, Context, Html, NodeRef},
 };
+
+use crate::fetch::{Common, Issues, Pulls, QueryIssue, QueryPull};
+use crate::top_pane::TopModel;
+use crate::CommonError;
 
 pub enum Message {
     IssueQueryResult(Vec<Issues>),


### PR DESCRIPTION
Closes #43
- Added `cargo fmt -- --check --config group_imports=StdExternalCrate` to `ci.yml` to enforce standardized import grouping.
- Reformatted source files to comply with this rule.