### PR TITLE
Fix Clippy warnings caused by rustc 1.86.0

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -123,6 +123,6 @@ pub trait Common: Component {
         } else {
             ctx.link()
                 .send_message(Self::common_error(CommonError::SendGraphQLQueryError));
-        };
+        }
     }
 }


### PR DESCRIPTION
closes #49