### PR TITLE
Minimize unnecessary pub access modifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ graphql_client = "0.14"
 indexmap = "2"
 implicit-clone = "0.5"
 js-sys = "0.3"
-serde = { version = "1",  features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wasm-bindgen = { version = "0.2"}
+wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
 yew = { version = "0.21", features = ["csr"] }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -15,7 +15,7 @@ use crate::CommonError;
     response_derives = "Clone, PartialEq, Debug"
 )]
 struct ServerIssues;
-pub type Issues = (String, String, i64, String, String);
+pub(crate) type Issues = (String, String, i64, String, String);
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -24,7 +24,7 @@ pub type Issues = (String, String, i64, String, String);
     response_derives = "Clone, PartialEq, Debug"
 )]
 struct ServerPulls;
-pub type Pulls = (String, String, i64, String, Vec<String>, Vec<String>);
+pub(crate) type Pulls = (String, String, i64, String, Vec<String>, Vec<String>);
 
 fn request<V>(query: &QueryBody<V>, token: &str) -> Result<Request>
 where
@@ -39,7 +39,7 @@ where
     Ok(request)
 }
 
-pub trait QueryIssue: Component + Common {
+pub(super) trait QueryIssue: Component + Common {
     fn success_issues_info(issues: Vec<Issues>) -> Self::Message;
 
     fn fetch_issue_info(&mut self, ctx: &Context<Self>, token: &str) {
@@ -67,7 +67,7 @@ pub trait QueryIssue: Component + Common {
     }
 }
 
-pub trait QueryPull: Component + Common {
+pub(super) trait QueryPull: Component + Common {
     fn success_pulls_info(issues: Vec<Pulls>) -> Self::Message;
 
     fn fetch_pulls_info(&mut self, ctx: &Context<Self>, token: &str) {
@@ -96,7 +96,7 @@ pub trait QueryPull: Component + Common {
     }
 }
 
-pub trait Common: Component {
+pub(super) trait Common: Component {
     fn common_error(error: CommonError) -> Self::Message;
 
     fn send_qeury<G, F>(&self, ctx: &Context<Self>, token: &str, var: G::Variables, f: F)
@@ -123,6 +123,6 @@ pub trait Common: Component {
         } else {
             ctx.link()
                 .send_message(Self::common_error(CommonError::SendGraphQLQueryError));
-        };
+        }
     }
 }

--- a/src/home.rs
+++ b/src/home.rs
@@ -13,14 +13,14 @@ use crate::fetch::{Common, Issues, Pulls, QueryIssue, QueryPull};
 use crate::top_pane::TopModel;
 use crate::CommonError;
 
-pub enum Message {
+pub(crate) enum Message {
     IssueQueryResult(Vec<Issues>),
     PullQueryResult(Vec<Pulls>),
     SignIn(Detail),
     Err(CommonError),
 }
 
-pub struct Model {
+pub(crate) struct Model {
     issue_res_query: Vec<Issues>,
     pull_res_query: Vec<Pulls>,
     node_ref: NodeRef,
@@ -30,7 +30,7 @@ pub struct Model {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct Detail {
+pub(super) struct Detail {
     pub email: String,
     pub token: String,
 }

--- a/src/top_pane.rs
+++ b/src/top_pane.rs
@@ -3,11 +3,11 @@ use yew::{
     {html, Component, Context, Html},
 };
 
-pub struct TopModel;
-pub enum Message {}
+pub(crate) struct TopModel;
+pub(crate) enum Message {}
 
 #[derive(Clone, Eq, PartialEq, Properties)]
-pub struct Props {
+pub(crate) struct Props {
     pub email: String,
 }
 


### PR DESCRIPTION
Closes #51

다음과 같은 기조로 접근자를 변경했습니다.

clippy 상으로 unnecessary pub access 진단이 나오는 코드 중,

1. parent mod에서만 사용되고 있어 pub(super)를 적용가능한 함수 / 모듈은 전부 pub(super) 적용
2. 그 외에 crate 내부에서 참조되고 있는 코드들은 pub(crate) 적용.
3. #[allow(unused)] 매크로가 사용되었거나 crate 내부 참조가 없는 코드는 pub을 삭제했습니다.
